### PR TITLE
fix: resolve auth fallback, add cross-platform browser support, and d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For detailed information on installation, configuration, and advanced usage, che
 - **Issue Browser**: View open issues with `:TicketsGithubFetch`.
 - **Deep Dive**: Press `<Enter>` on an issue to view the full description, metadata, and comments.
 - **Performance**: Smart in-memory caching for instant subsequent loads.
-- **Flexible Auth**: Works seamlessly with the `gh` CLI or `GITHUB_TOKEN`.
+- **GitHub CLI**: Requires the [`gh` CLI](https://cli.github.com/) for GitHub features (`gh auth login`).
 
 ## 📦 Installation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,8 @@
 
 Tickets.nvim requires **Neovim >= 0.8.0** and depends on [plenary.nvim](https://github.com/nvim-lua/plenary.nvim).
 
+GitHub features require the [GitHub CLI (`gh`)](https://cli.github.com/) to be installed and authenticated via `gh auth login`.
+
 ## using lazy.nvim
 
 ```lua

--- a/lua/tickets/create.lua
+++ b/lua/tickets/create.lua
@@ -268,7 +268,8 @@ function M.submit_issue(buf)
         cache.invalidate(repo)
 
         -- Optionally open the URL in browser
-        vim.fn.jobstart({ "open", url }, { detach = true })
+        local utils = require("tickets.utils")
+        utils.open_url(url)
     end)
 end
 

--- a/lua/tickets/github.lua
+++ b/lua/tickets/github.lua
@@ -4,7 +4,7 @@ local utils = require("tickets.utils")
 local cache = require("tickets.cache")
 local M = {}
 
--- Check if gh CLI is available and authenticated
+-- Check if gh CLI is available and authenticated via keyring
 local function is_gh_available()
     local handle = io.popen("gh auth status 2>&1")
     if not handle then
@@ -13,7 +13,14 @@ local function is_gh_available()
     local result = handle:read("*a")
     handle:close()
 
-    -- Check if logged in AND that there's no invalid token error
+    -- Check for a valid keyring-based login, which is reliable even when
+    -- GITHUB_TOKEN is set but invalid
+    local has_keyring = result:match("Logged in to github%.com account %S+ %(keyring%)") ~= nil
+    if has_keyring then
+        return true
+    end
+
+    -- Fall back to checking for any valid login without token errors
     local has_login = result:match("Logged in") ~= nil
     local has_invalid_token = result:match("invalid") ~= nil or result:match("Failed to log in") ~= nil
 

--- a/lua/tickets/ui/issue_list.lua
+++ b/lua/tickets/ui/issue_list.lua
@@ -5,6 +5,7 @@ local config = require("tickets.ui.config")
 local formatters = require("tickets.ui.formatters")
 local issue_detail = require("tickets.ui.issue_detail")
 local prefetch = require("tickets.ui.prefetch")
+local utils = require("tickets.utils")
 
 -- Find which issue line the cursor is on
 -- @param buf number: Buffer handle
@@ -54,7 +55,7 @@ local function setup_keymaps(buf, win, issues, repo)
         if issue then
             local url = issue.html_url
             if url then
-                vim.fn.jobstart({ "open", url }, { detach = true })
+                utils.open_url(url)
                 vim.notify("Opening issue in browser...", vim.log.levels.INFO)
             end
         end

--- a/lua/tickets/utils.lua
+++ b/lua/tickets/utils.lua
@@ -48,4 +48,24 @@ function M.get_current_repo()
     return nil
 end
 
+function M.get_open_command()
+    local sysname = vim.loop.os_uname().sysname
+    if sysname == "Darwin" then
+        return "open"
+    elseif sysname == "Windows_NT" then
+        return "cmd"
+    else
+        return "xdg-open"
+    end
+end
+
+function M.open_url(url)
+    local cmd = M.get_open_command()
+    if cmd == "cmd" then
+        vim.fn.jobstart({ "cmd", "/c", "start", url }, { detach = true })
+    else
+        vim.fn.jobstart({ cmd, url }, { detach = true })
+    end
+end
+
 return M


### PR DESCRIPTION
…ocument gh CLI requirement

Auth: An invalid GITHUB_TOKEN environment variable caused is_gh_available() to return false even when a valid keyring-based gh login existed, forcing the curl fallback path which then failed with a 401. The check now prioritizes keyring authentication, so a stale or invalid GITHUB_TOKEN no longer blocks valid gh CLI auth.

Browser: The hardcoded macOS `open` command in issue_list.lua and create.lua is replaced with a cross-platform utils.open_url() helper that detects the OS via vim.loop.os_uname() and dispatches to `open` (macOS), `xdg-open` (Linux), or `cmd /c start` (Windows).

Docs: The gh CLI is now documented as a required dependency for GitHub features in both README.md and docs/installation.md, replacing the previous misleading "Works seamlessly with gh CLI or GITHUB_TOKEN" language, since issue details and issue creation both hard-require gh.